### PR TITLE
Add neg testcases

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -51,7 +51,9 @@ module.exports = config => {
     .then(res => {
       if (verbose) console.log('reallyLogin res', res.body)
       if (res.headers['set-cookie']) {
-        return _.extractCookies(res)
+        const cookies = _.extractCookies(res)
+        if (sessionCookiePattern.test(cookies)) return cookies
+        else throw new Error('failed to get login cookies (probably because the provided username/password are invalid)')
       } else {
         const err = new Error('login error')
         err.statusCode = res.statusCode
@@ -64,3 +66,5 @@ module.exports = config => {
   // login just once, then use the same data consuming the same promise
   return login()
 }
+
+const sessionCookiePattern = /[sS]ession=\w{32}/

--- a/test/main.js
+++ b/test/main.js
@@ -13,10 +13,10 @@ describe('wikibase-token', function () {
     .then(res => {
       res.token.length.should.be.above(40)
       const { cookie } = res
-      should(/wikibase_session=\w{32}/.test(cookie)).be.true()
-      should(/wikibaseUserID=\d+/.test(cookie)).be.true()
-      should(/wikibaseUserName=\w+/.test(cookie)).be.true()
-      should(/wikibaseToken=\w+/.test(cookie)).be.true()
+      should(/.+[sS]ession=\w{32}/.test(cookie)).be.true( 'should contain session ID' )
+      should(/.+UserID=\d+/.test(cookie)).be.true( 'should contain user ID' )
+      should(/.+UserName=\w+/.test(cookie)).be.true( 'should contain username' )
+      should(/.+Token=\w+/.test(cookie)).be.true( 'should contain token' )
       done()
     })
     .catch(done)

--- a/test/main.js
+++ b/test/main.js
@@ -13,10 +13,10 @@ describe('wikibase-token', function () {
     .then(res => {
       res.token.length.should.be.above(40)
       const { cookie } = res
-      should(/.+[sS]ession=\w{32}/.test(cookie)).be.true( 'should contain session ID' )
-      should(/.+UserID=\d+/.test(cookie)).be.true( 'should contain user ID' )
-      should(/.+UserName=\w+/.test(cookie)).be.true( 'should contain username' )
-      should(/.+Token=\w+/.test(cookie)).be.true( 'should contain token' )
+      should(/.+[sS]ession=\w{32}/.test(cookie)).be.true('should contain session ID')
+      should(/.+UserID=\d+/.test(cookie)).be.true('should contain user ID')
+      should(/.+UserName=\w+/.test(cookie)).be.true('should contain username')
+      should(/.+Token=\w+/.test(cookie)).be.true('should contain token')
       done()
     })
     .catch(done)
@@ -33,13 +33,19 @@ describe('wikibase-token', function () {
     .catch(done)
   })
 
-  it( 'should reject on invalid username/password credentials', () => {
+  it('should reject on invalid username/password credentials', done => {
     const tokenGetter = wikibaseToken({ instance, username: 'inva', password: 'lid' })
     tokenGetter.should.be.a.Function()
-    return tokenGetter().should.be.rejected()
+    tokenGetter()
+    .then(undesiredRes(done))
+    .catch(err => {
+      err.message.should.startWith('failed to get login cookies')
+      done()
+    })
+    .catch(done)
   })
 
-  it( 'should reject on invalid oauth credentials', () => {
+  it('should reject on invalid oauth credentials',  done => {
     const tokenGetter = wikibaseToken({ instance, oauth: {
         consumer_key:     'in',
         consumer_secret:  'va',
@@ -48,7 +54,14 @@ describe('wikibase-token', function () {
       }
     })
     tokenGetter.should.be.a.Function()
-    return tokenGetter().should.be.rejected()
+    tokenGetter()
+    .then(undesiredRes(done))
+    .catch(err => {
+      err.message.should.endWith('Invalid consumer')
+      done()
+    })
+    .catch(done)
   })
-
 })
+
+const undesiredRes = done => () => done(new Error("shouldn't have been called"))

--- a/test/main.js
+++ b/test/main.js
@@ -32,4 +32,23 @@ describe('wikibase-token', function () {
     })
     .catch(done)
   })
+
+  it( 'should reject on invalid username/password credentials', () => {
+    const tokenGetter = wikibaseToken({ instance, username: 'inva', password: 'lid' })
+    tokenGetter.should.be.a.Function()
+    return tokenGetter().should.be.rejected()
+  })
+
+  it( 'should reject on invalid oauth credentials', () => {
+    const tokenGetter = wikibaseToken({ instance, oauth: {
+        consumer_key:     'in',
+        consumer_secret:  'va',
+        token:            'li',
+        token_secret:     'd'
+      }
+    })
+    tokenGetter.should.be.a.Function()
+    return tokenGetter().should.be.rejected()
+  })
+
 })


### PR DESCRIPTION
While testing for https://github.com/maxlath/wikibase-edit/pull/47, I noticed some issues with the tests here as well:

1. Checking the contents of the cookies relied on some (old?) namings. Even testing with the current Wikidata instance, the tests would not pass. I tried to make the assertions here a little more flexible.

2. Tests were missing to check the failing after wrong credentials. I added those as well. 

Note, that one of the new test is currently failing. Basically using wrong OAuth credentials, Wikibase seems to return an empty token, which is passed on by the lib not detecting the actual error.
